### PR TITLE
fix: migrate Q API endpoint from q.amazonaws.com to runtime.kiro.dev

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func getQApiEndpoint() string {
 	if region == "" {
 		region = "us-east-1"
 	}
-	return fmt.Sprintf("https://q.%s.amazonaws.com/", region)
+	return fmt.Sprintf("https://runtime.%s.kiro.dev/", region)
 }
 
 // getKiroCliDbPath 获取kiro-cli SQLite数据库路径


### PR DESCRIPTION
Legacy q.<region>.amazonaws.com endpoint will be deactivated on May 15, 2026. Migrate to new runtime.<region>.kiro.dev endpoint per Kiro service announcement.