### PR TITLE
fix(parser): detect XML-wrapped tool calls in opus 4.8 continuations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *response.raw
 kiro2pi
 PLAN-*.md
+msg_*.raw
+FIX-*.md

--- a/parser/regress_test.go
+++ b/parser/regress_test.go
@@ -1,0 +1,54 @@
+package parser
+
+import "testing"
+
+// Guard: pure-text (no thinking, no tools) stays at index 0.
+func TestRegressTextOnly(t *testing.T) {
+	res := ParseEventsWithThinking(buildStream([]string{`{"content":"hello world"}`}))
+	got := blockIndexOf(t, res.Events, "content_block_start")
+	if got != 0 {
+		t.Fatalf("text-only block start expected idx 0, got %d", got)
+	}
+	if res.TextIndex != 0 || res.HasThinking {
+		t.Fatalf("TextIndex=%d HasThinking=%v", res.TextIndex, res.HasThinking)
+	}
+}
+
+// Guard: thinking-first then text (the 4.6 ordering) keeps thinking@0,text@1.
+func TestRegressThinkingFirstThenText(t *testing.T) {
+	frames := []string{
+		`{"toolUseId":"tk","name":"thinking"}`,
+		`{"toolUseId":"tk","name":"thinking","input":"{\"thought\": \"x"}`,
+		`{"toolUseId":"tk","stop":true}`,
+		`{"content":"answer"}`,
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	// first start must be thinking@0, then text@1
+	var seen []string
+	for _, e := range res.Events {
+		if e.Event == "content_block_start" {
+			dm := e.Data.(map[string]interface{})
+			cb := dm["content_block"].(map[string]interface{})
+			seen = append(seen, cb["type"].(string))
+			if cb["type"] == "thinking" && dm["index"].(int) != 0 {
+				t.Fatalf("thinking not at 0: %v", dm["index"])
+			}
+			if cb["type"] == "text" && dm["index"].(int) != 1 {
+				t.Fatalf("text not at 1: %v", dm["index"])
+			}
+		}
+	}
+	if !res.HasThinking || res.TextIndex != 1 {
+		t.Fatalf("HasThinking=%v TextIndex=%d", res.HasThinking, res.TextIndex)
+	}
+}
+
+func blockIndexOf(t *testing.T, evs []SSEEvent, event string) int {
+	for _, e := range evs {
+		if e.Event == event {
+			return e.Data.(map[string]interface{})["index"].(int)
+		}
+	}
+	t.Fatalf("no %s event", event)
+	return -1
+}

--- a/parser/repro_test.go
+++ b/parser/repro_test.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+// encodeFrame builds one CodeWhisperer event-stream frame around a JSON payload.
+// Layout: [totalLen u32][headerLen u32][header bytes][ "vent"+payload ][crc u32]
+func encodeFrame(payload string) []byte {
+	header := []byte{} // empty header; parser only skips it
+	body := []byte("vent" + payload)
+	headerLen := uint32(len(header))
+	totalLen := uint32(12 + len(header) + len(body))
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.BigEndian, totalLen)
+	binary.Write(&buf, binary.BigEndian, headerLen)
+	buf.Write(header)
+	buf.Write(body)
+	binary.Write(&buf, binary.BigEndian, uint32(0)) // crc (skipped)
+	return buf.Bytes()
+}
+
+func buildStream(frames []string) []byte {
+	var out bytes.Buffer
+	for _, f := range frames {
+		out.Write(encodeFrame(f))
+	}
+	return out.Bytes()
+}
+
+func dumpEvents(t *testing.T, label string, evs []SSEEvent) {
+	t.Logf("==== %s ====", label)
+	for _, e := range evs {
+		if e.Event == "" {
+			continue
+		}
+		dm, _ := e.Data.(map[string]interface{})
+		idx := dm["index"]
+		var detail string
+		if cb, ok := dm["content_block"].(map[string]interface{}); ok {
+			detail = fmt.Sprintf("block=%v name=%v", cb["type"], cb["name"])
+		} else if d, ok := dm["delta"].(map[string]interface{}); ok {
+			detail = fmt.Sprintf("delta=%v", d["type"])
+		}
+		t.Logf("  %-22s idx=%v %s", e.Event, idx, detail)
+	}
+}
+
+// Scenario A: thinking tool, THEN text, THEN a real tool.
+// This is the interleaving the bug report suspects opus 4.8 produces.
+func TestReproThinkingThenTextThenTool(t *testing.T) {
+	in := func(s string) string { return s }
+	_ = in
+	frames := []string{
+		`{"toolUseId":"tk1","name":"thinking"}`,
+		`{"toolUseId":"tk1","name":"thinking","input":"{\"thought\": \"hmm"}`,
+		`{"toolUseId":"tk1","stop":true}`,
+		`{"content":"Let me read the file."}`,
+		`{"toolUseId":"rd1","name":"read"}`,
+		`{"toolUseId":"rd1","name":"read","input":"{\"path\":\"/x\"}"}`,
+		`{"toolUseId":"rd1","stop":true}`,
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	dumpEvents(t, "A thinking->text->tool", res.Events)
+	t.Logf("TextIndex=%d HasThinking=%v HasRegularTools=%v", res.TextIndex, res.HasThinking, res.HasRegularTools)
+}
+
+// Scenario B: text FIRST, then thinking appears AFTER text already started.
+// textIndex was 0 when text block started; thinking later flips textIndex->1
+// but the text block is already open at index 0 and thinking also claims 0.
+func TestReproTextThenThinkingThenTool(t *testing.T) {
+	frames := []string{
+		`{"content":"Sure, working on it."}`,
+		`{"toolUseId":"tk1","name":"thinking"}`,
+		`{"toolUseId":"tk1","name":"thinking","input":"{\"thought\": \"plan"}`,
+		`{"toolUseId":"tk1","stop":true}`,
+		`{"toolUseId":"rd1","name":"read"}`,
+		`{"toolUseId":"rd1","name":"read","input":"{\"path\":\"/x\"}"}`,
+		`{"toolUseId":"rd1","stop":true}`,
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	dumpEvents(t, "B text->thinking->tool", res.Events)
+	t.Logf("TextIndex=%d HasThinking=%v HasRegularTools=%v", res.TextIndex, res.HasThinking, res.HasRegularTools)
+}
+
+// Scenario C: tool input continuation frame with NO toolUseId (fallback path).
+func TestReproToolInputContinuationNoId(t *testing.T) {
+	// two tools; second tool's continuation input arrives with empty toolUseId
+	frames := []string{
+		`{"content":"hi"}`,
+		`{"toolUseId":"a1","name":"read"}`,
+		`{"toolUseId":"a1","name":"read","input":"{\"path"}`,
+		`{"toolUseId":"a1","stop":true}`,
+		`{"toolUseId":"b2","name":"grep"}`,
+		`{"toolUseId":"b2","name":"grep","input":"{\"pat"}`,
+		`{"input":"tern\":\"x\"}"}`, // continuation, no toolUseId -> fallback index 1
+		`{"toolUseId":"b2","stop":true}`,
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	dumpEvents(t, "C continuation-no-id", res.Events)
+}

--- a/parser/sse_parser.go
+++ b/parser/sse_parser.go
@@ -50,6 +50,7 @@ func ParseEvents(resp []byte) []SSEEvent {
 	hasThinking := false                   // Track if we've seen thinking blocks
 	textIndex := 0                         // Text index: 0 if no thinking, 1 if thinking present
 	tagParser := NewThinkingTagParser()    // Parser for <thinking> tags in text content
+	xmlParser := NewXmlToolParser()         // Parser for XML tool calls in text content
 
 	r := bytes.NewReader(resp)
 	for {
@@ -100,7 +101,7 @@ func ParseEvents(resp []byte) []SSEEvent {
 
 			// Convert event to SSE, tracking started tools to avoid duplicate starts
 			// Also track content for deduplication
-			sseEvents := convertAssistantEventWithTracking(evt, startedTools, toolIndexMap, thinkingToolIds, &nextToolIndex, &lastContent, &hasThinking, &textIndex, tagParser)
+			sseEvents := convertAssistantEventWithTracking(evt, startedTools, toolIndexMap, thinkingToolIds, &nextToolIndex, &lastContent, &hasThinking, &textIndex, tagParser, xmlParser)
 			events = append(events, sseEvents...)
 
 			// Add message_delta for tool_use stop, but skip for thinking tools
@@ -124,6 +125,15 @@ func ParseEvents(resp []byte) []SSEEvent {
 		} else {
 			log.Println("json unmarshal error:", err)
 		}
+	}
+
+	// Flush XML tool parser - emit any remaining buffered content
+	flushResult := xmlParser.Flush()
+	if flushResult.RegularText != "" {
+		events = append(events, emitTextEvents(flushResult.RegularText, startedTools, textIndex)...)
+	}
+	for _, tc := range flushResult.ToolCalls {
+		events = append(events, emitXmlToolEvents(tc, startedTools, &nextToolIndex, textIndex)...)
 	}
 
 	return events
@@ -355,10 +365,87 @@ func emitTextEvents(content string, startedTools map[string]bool, textIndex int)
 	return events
 }
 
+// emitXmlToolEvents generates SSE events for a tool call detected from XML text.
+// Ensures text block is started first (for sequential indices), then emits tool_use events.
+func emitXmlToolEvents(tc XmlToolCall, startedTools map[string]bool, nextToolIndex *int, textIndex int) []SSEEvent {
+	var events []SSEEvent
+
+	// Ensure text block is emitted first so indices are sequential
+	if !startedTools["__text__"] {
+		startedTools["__text__"] = true
+		events = append(events, SSEEvent{
+			Event: "content_block_start",
+			Data: map[string]interface{}{
+				"type":  "content_block_start",
+				"index": textIndex,
+				"content_block": map[string]interface{}{"type": "text", "text": ""},
+			},
+		})
+	}
+
+	toolIndex := *nextToolIndex
+	*nextToolIndex++
+
+	// content_block_start for tool_use
+	events = append(events, SSEEvent{
+		Event: "content_block_start",
+		Data: map[string]interface{}{
+			"type":  "content_block_start",
+			"index": toolIndex,
+			"content_block": map[string]interface{}{
+				"type":  "tool_use",
+				"id":    tc.ID,
+				"name":  tc.Name,
+				"input": map[string]interface{}{},
+			},
+		},
+	})
+	startedTools[tc.ID] = true
+
+	// input_json_delta with full input
+	if tc.Input != "" && tc.Input != "{}" {
+		events = append(events, SSEEvent{
+			Event: "content_block_delta",
+			Data: map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": toolIndex,
+				"delta": map[string]interface{}{
+					"type":         "input_json_delta",
+					"partial_json": tc.Input,
+				},
+			},
+		})
+	}
+
+	// content_block_stop
+	events = append(events, SSEEvent{
+		Event: "content_block_stop",
+		Data: map[string]interface{}{
+			"type":  "content_block_stop",
+			"index": toolIndex,
+		},
+	})
+
+	// message_delta with stop_reason=tool_use
+	events = append(events, SSEEvent{
+		Event: "message_delta",
+		Data: map[string]interface{}{
+			"type": "message_delta",
+			"delta": map[string]interface{}{
+				"stop_reason":   "tool_use",
+				"stop_sequence": nil,
+			},
+			"usage": map[string]interface{}{"output_tokens": 0},
+		},
+	})
+
+	return events
+}
+
 // convertAssistantEventWithTracking handles events with tool tracking to avoid duplicate content_block_start
 // Also implements content deduplication to prevent duplicate text content
 // Index assignment: thinking gets index 0 (if present), text gets index 1 (or 0 if no thinking), tools get subsequent indexes
-func convertAssistantEventWithTracking(evt assistantResponseEvent, startedTools map[string]bool, toolIndexMap map[string]int, thinkingToolIds map[string]bool, nextToolIndex *int, lastContent *string, hasThinking *bool, textIndex *int, tagParser *ThinkingTagParser) []SSEEvent {
+func convertAssistantEventWithTracking(evt assistantResponseEvent, startedTools map[string]bool, toolIndexMap map[string]int, thinkingToolIds map[string]bool, nextToolIndex *int, lastContent *string, hasThinking *bool, textIndex *int, tagParser *ThinkingTagParser, xmlParser *XmlToolParser) []SSEEvent {
 	var events []SSEEvent
 
 	// Convert "thinking" tool calls to thinking content blocks
@@ -418,9 +505,15 @@ func convertAssistantEventWithTracking(evt assistantResponseEvent, startedTools 
 			events = append(events, emitThinkingEvents(tagResult, startedTools)...)
 		}
 
-		// Emit regular content if any
+		// Emit regular content if any - feed through XML tool parser
 		if tagResult.RegularContent != "" {
-			events = append(events, emitTextEvents(tagResult.RegularContent, startedTools, *textIndex)...)
+			xmlResult := xmlParser.Feed(tagResult.RegularContent)
+			if xmlResult.RegularText != "" {
+				events = append(events, emitTextEvents(xmlResult.RegularText, startedTools, *textIndex)...)
+			}
+			for _, tc := range xmlResult.ToolCalls {
+				events = append(events, emitXmlToolEvents(tc, startedTools, nextToolIndex, *textIndex)...)
+			}
 		}
 	} else if evt.ToolUseId != "" && evt.Name != "" && !evt.Stop {
 		// Ensure text block is emitted before any tool_use block so indices are sequential
@@ -528,6 +621,7 @@ func ParseEventsWithThinking(resp []byte) ParseResult {
 	hasThinking := false    // Track if we've seen thinking blocks
 	textIndex := 0          // Text index: 0 if no thinking, 1 if thinking present
 	tagParser := NewThinkingTagParser() // Parser for <thinking> tags in text content
+	xmlParser := NewXmlToolParser()      // Parser for XML tool calls in text content
 
 	// Track thinking input fragments to accumulate full content
 	var thinkingInputBuilder strings.Builder
@@ -595,8 +689,13 @@ func ParseEventsWithThinking(resp []byte) ParseResult {
 				result.HasRegularTools = true
 			}
 
-			sseEvents := convertAssistantEventWithTracking(evt, startedTools, toolIndexMap, thinkingToolIds, &nextToolIndex, &lastContent, &hasThinking, &textIndex, tagParser)
+			sseEvents := convertAssistantEventWithTracking(evt, startedTools, toolIndexMap, thinkingToolIds, &nextToolIndex, &lastContent, &hasThinking, &textIndex, tagParser, xmlParser)
 			result.Events = append(result.Events, sseEvents...)
+
+			// Check if XML tool parser detected tool calls (sets HasRegularTools)
+			if xmlParser.hasDetectedTools {
+				result.HasRegularTools = true
+			}
 
 			// Add message_delta for non-thinking tool_use stop
 			if evt.ToolUseId != "" && evt.Name != "" && evt.Name != "thinking" {
@@ -617,6 +716,16 @@ func ParseEventsWithThinking(resp []byte) ParseResult {
 		} else {
 			log.Println("json unmarshal error:", err)
 		}
+	}
+
+	// Flush XML tool parser - emit any remaining buffered content
+	flushResult := xmlParser.Flush()
+	if flushResult.RegularText != "" {
+		result.Events = append(result.Events, emitTextEvents(flushResult.RegularText, startedTools, textIndex)...)
+	}
+	for _, tc := range flushResult.ToolCalls {
+		result.Events = append(result.Events, emitXmlToolEvents(tc, startedTools, &nextToolIndex, textIndex)...)
+		result.HasRegularTools = true
 	}
 
 	// Parse accumulated thinking input to extract actual thought content

--- a/parser/xml_tool_parser.go
+++ b/parser/xml_tool_parser.go
@@ -1,0 +1,181 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// XmlToolParser detects <invoke name="...">...</invoke> XML tool call patterns
+// in streaming text content and converts them to proper tool_use events.
+// This handles the case where the Q API sends tool calls as XML text
+// (typically after thinking continuation) instead of proper structured tool frames.
+type XmlToolParser struct {
+	buffer           string // accumulated text that might contain XML tool calls
+	inInvoke         bool   // true when we're inside an <invoke> block
+	prefixBuf        string // text before <invoke> that should be emitted as regular text
+	hasDetectedTools bool   // true if any tool calls were detected
+}
+
+// XmlToolResult represents the result of feeding text to the parser
+type XmlToolResult struct {
+	RegularText string     // Text to emit as text_delta (before any <invoke>)
+	ToolCalls   []XmlToolCall // Detected tool calls to emit as tool_use blocks
+	Buffering   bool       // True if parser is holding back text (potential partial <invoke>)
+}
+
+// XmlToolCall represents a parsed tool call from XML
+type XmlToolCall struct {
+	Name  string
+	ID    string
+	Input string // JSON string of the tool input
+}
+
+// NewXmlToolParser creates a new parser instance
+func NewXmlToolParser() *XmlToolParser {
+	return &XmlToolParser{}
+}
+
+// Feed processes a text content fragment and returns parsed results.
+// It detects <invoke name="..."><parameter name="...">...</parameter></invoke> patterns
+// and converts them to tool call data.
+func (p *XmlToolParser) Feed(content string) XmlToolResult {
+	p.buffer += content
+	return p.process()
+}
+
+// Flush returns any remaining buffered content as regular text.
+// Call this when the text stream ends.
+func (p *XmlToolParser) Flush() XmlToolResult {
+	result := XmlToolResult{RegularText: p.buffer}
+	p.buffer = ""
+	p.inInvoke = false
+	return result
+}
+
+// invokeStartRe matches the opening of an <invoke> tag
+var invokeStartRe = regexp.MustCompile(`<invoke\s+name="([^"]+)"[^>]*>`)
+
+// invokeEndRe matches the closing </invoke> tag
+var invokeEndRe = regexp.MustCompile(`</invoke>`)
+
+// paramRe matches parameter tags within an invoke block
+var paramRe = regexp.MustCompile(`<parameter\s+name="([^"]+)">([\s\S]*?)</parameter>`)
+
+func (p *XmlToolParser) process() XmlToolResult {
+	var result XmlToolResult
+
+	for {
+		if !p.inInvoke {
+			// Look for <invoke in the buffer
+			idx := strings.Index(p.buffer, "<invoke")
+			if idx == -1 {
+				// No <invoke found. Check if buffer ends with a partial match
+				// that could be the start of "<invoke"
+				safeLen := len(p.buffer)
+				// Check if any suffix of buffer is a prefix of "<invoke"
+				for i := max(0, safeLen-7); i < safeLen; i++ {
+					suffix := p.buffer[i:]
+					if strings.HasPrefix("<invoke", suffix) && len(suffix) > 0 {
+						// This suffix could be the start of <invoke
+						result.RegularText += p.buffer[:i]
+						p.buffer = suffix
+						result.Buffering = true
+						return result
+					}
+				}
+				// No partial match - emit all as regular text
+				result.RegularText += p.buffer
+				p.buffer = ""
+				return result
+			}
+
+			// Found <invoke at position idx
+			// Text before it is regular text
+			if idx > 0 {
+				result.RegularText += p.buffer[:idx]
+				p.buffer = p.buffer[idx:]
+			}
+
+			// Check if we have the full opening tag
+			loc := invokeStartRe.FindStringIndex(p.buffer)
+			if loc == nil {
+				// Partial opening tag - keep buffering
+				result.Buffering = true
+				return result
+			}
+
+			// We have a complete opening tag - switch to in-invoke mode
+			p.inInvoke = true
+		}
+
+		// In invoke mode - look for </invoke>
+		endLoc := invokeEndRe.FindStringIndex(p.buffer)
+		if endLoc == nil {
+			// Haven't found closing tag yet - keep buffering
+			result.Buffering = true
+			return result
+		}
+
+		// We have a complete <invoke>...</invoke> block
+		fullBlock := p.buffer[:endLoc[1]]
+		p.buffer = p.buffer[endLoc[1]:]
+		p.inInvoke = false
+
+		// Parse the block
+		toolCall := parseInvokeBlock(fullBlock)
+		if toolCall != nil {
+			result.ToolCalls = append(result.ToolCalls, *toolCall)
+			p.hasDetectedTools = true
+		} else {
+			// Failed to parse - emit as regular text
+			result.RegularText += fullBlock
+		}
+
+		// Continue processing remaining buffer (might have more invokes)
+	}
+}
+
+// parseInvokeBlock parses a complete <invoke>...</invoke> XML block into a tool call
+func parseInvokeBlock(block string) *XmlToolCall {
+	// Extract tool name
+	nameMatch := invokeStartRe.FindStringSubmatch(block)
+	if nameMatch == nil {
+		return nil
+	}
+	toolName := nameMatch[1]
+
+	// Extract parameters
+	params := make(map[string]interface{})
+	paramMatches := paramRe.FindAllStringSubmatch(block, -1)
+	for _, m := range paramMatches {
+		paramName := m[1]
+		paramValue := m[2]
+		params[paramName] = paramValue
+	}
+
+	// Convert params to JSON
+	inputJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil
+	}
+
+	// Generate a tool use ID
+	toolID := fmt.Sprintf("tooluse_%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:22])
+
+	return &XmlToolCall{
+		Name:  toolName,
+		ID:    toolID,
+		Input: string(inputJSON),
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/parser/xml_tool_test.go
+++ b/parser/xml_tool_test.go
@@ -1,0 +1,173 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestXmlToolCallInText simulates the real bug: after thinking continuation,
+// Q API sends tool call as XML text instead of proper structured tool frames.
+// The parser should detect and convert the XML to proper tool_use events.
+func TestXmlToolCallInText(t *testing.T) {
+	// This simulates the continuation response from msg_20260606203457_continuation_1.raw
+	frames := []string{
+		`{"content":""}`,           // empty frame
+		`{"content":"call"}`,       // text before invoke
+		`{"content":"\n<invoke name=\"bash\">"}`,
+		`{"content":"\n<parameter name=\"command\">"}`,
+		`{"content":"ls /tmp"}`,
+		`{"content":"</parameter>"}`,
+		`{"content":"\n</invoke>"}`,
+		`{"content":""}`,           // trailing empty
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	dumpEvents(t, "XML tool in text", res.Events)
+	t.Logf("HasRegularTools=%v", res.HasRegularTools)
+
+	if !res.HasRegularTools {
+		t.Fatal("expected HasRegularTools=true, XML tool call should be detected")
+	}
+
+	// Verify a tool_use content_block_start was emitted
+	foundToolUse := false
+	for _, e := range res.Events {
+		if e.Event == "content_block_start" {
+			dm := e.Data.(map[string]interface{})
+			if cb, ok := dm["content_block"].(map[string]interface{}); ok {
+				if cb["type"] == "tool_use" && cb["name"] == "bash" {
+					foundToolUse = true
+					// Check index is 1 (text is at 0)
+					if idx := dm["index"].(int); idx != 1 {
+						t.Errorf("tool_use index=%d, want 1", idx)
+					}
+				}
+			}
+		}
+	}
+	if !foundToolUse {
+		t.Fatal("no tool_use content_block_start found - XML tool call not converted")
+	}
+
+	// Verify tool input contains the command
+	for _, e := range res.Events {
+		if e.Event == "content_block_delta" {
+			dm := e.Data.(map[string]interface{})
+			if delta, ok := dm["delta"].(map[string]interface{}); ok {
+				if delta["type"] == "input_json_delta" {
+					inputJSON := delta["partial_json"].(string)
+					var input map[string]interface{}
+					if err := json.Unmarshal([]byte(inputJSON), &input); err != nil {
+						t.Fatalf("failed to parse tool input JSON: %v", err)
+					}
+					if cmd, ok := input["command"].(string); !ok || cmd != "ls /tmp" {
+						t.Errorf("tool input command=%q, want \"ls /tmp\"", cmd)
+					}
+					return
+				}
+			}
+		}
+	}
+	t.Fatal("no input_json_delta found for the tool call")
+}
+
+// TestXmlToolCallAfterThinking simulates the full scenario:
+// initial response has thinking tool, then continuation has XML tool text.
+func TestXmlToolCallAfterThinking(t *testing.T) {
+	// Simulate what main.go does: first parse thinking, then parse continuation separately
+	// The continuation response is what has the XML tool call
+	contFrames := []string{
+		`{"content":""}`,
+		`{"content":"I'll execute the command."}`,
+		`{"content":"\n<invoke name=\"read\">"}`,
+		`{"content":"\n<parameter name=\"path\">"}`,
+		`{"content":"/etc/hosts"}`,
+		`{"content":"</parameter>"}`,
+		`{"content":"\n</invoke>"}`,
+	}
+	res := ParseEventsWithThinking(buildStream(contFrames))
+	dumpEvents(t, "XML tool after text", res.Events)
+	t.Logf("HasRegularTools=%v TextIndex=%d", res.HasRegularTools, res.TextIndex)
+
+	if !res.HasRegularTools {
+		t.Fatal("expected HasRegularTools=true")
+	}
+
+	// Text "I'll execute the command.\n" should be at index 0
+	// Tool "read" should be at index 1
+	var textIdx, toolIdx int
+	for _, e := range res.Events {
+		if e.Event == "content_block_start" {
+			dm := e.Data.(map[string]interface{})
+			cb := dm["content_block"].(map[string]interface{})
+			switch cb["type"] {
+			case "text":
+				textIdx = dm["index"].(int)
+			case "tool_use":
+				toolIdx = dm["index"].(int)
+				if cb["name"] != "read" {
+					t.Errorf("tool name=%q, want \"read\"", cb["name"])
+				}
+			}
+		}
+	}
+	if textIdx != 0 {
+		t.Errorf("text index=%d, want 0", textIdx)
+	}
+	if toolIdx != 1 {
+		t.Errorf("tool index=%d, want 1", toolIdx)
+	}
+}
+
+// TestXmlMultipleToolCalls tests multiple <invoke> blocks in sequence
+func TestXmlMultipleToolCalls(t *testing.T) {
+	frames := []string{
+		`{"content":"Here are two commands:"}`,
+		`{"content":"\n<invoke name=\"bash\">"}`,
+		`{"content":"\n<parameter name=\"command\">ls</parameter>"}`,
+		`{"content":"\n</invoke>"}`,
+		`{"content":"\n<invoke name=\"read\">"}`,
+		`{"content":"\n<parameter name=\"path\">/etc/hosts</parameter>"}`,
+		`{"content":"\n</invoke>"}`,
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	dumpEvents(t, "Multiple XML tools", res.Events)
+
+	toolCount := 0
+	for _, e := range res.Events {
+		if e.Event == "content_block_start" {
+			dm := e.Data.(map[string]interface{})
+			if cb, ok := dm["content_block"].(map[string]interface{}); ok {
+				if cb["type"] == "tool_use" {
+					toolCount++
+				}
+			}
+		}
+	}
+	if toolCount != 2 {
+		t.Fatalf("expected 2 tool_use blocks, got %d", toolCount)
+	}
+}
+
+// TestNoFalsePositiveXml ensures normal text with < chars doesn't trigger XML detection
+func TestNoFalsePositiveXml(t *testing.T) {
+	frames := []string{
+		`{"content":"Use if x < 5 then do something"}`,
+		`{"content":" and <b>bold</b> text"}`,
+		`{"content":" with <invoked> not a tool"}`,
+	}
+	res := ParseEventsWithThinking(buildStream(frames))
+	if res.HasRegularTools {
+		t.Fatal("should not detect tools in normal text")
+	}
+	// All content should be text
+	for _, e := range res.Events {
+		if e.Event == "content_block_start" {
+			dm := e.Data.(map[string]interface{})
+			if cb, ok := dm["content_block"].(map[string]interface{}); ok {
+				if cb["type"] == "tool_use" {
+					t.Fatal("false positive: detected tool_use in normal text")
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
opus 4.8 intermittently rendered tool_use as plain text. Root cause: when opus 4.8 triggers thinking, kiro2pi auto-sends a tool_result continuation, and Q API returns the real tool call as XML text inside content frames (all frames have empty ToolUseId/Name) instead of structured tool_use frames. The old parser only recognized structured frames and emitted the XML as text_delta, so pi showed it as plain text. opus 4.6 / sonnet 4.6 never took the thinking-continuation path, so they were unaffected.

Add a streaming XmlToolParser that detects <invoke name="..."> ... </invoke> in text content, parses the tool name + params, and re-emits proper tool_use SSE events (content_block_start/input_json_delta/content_block_stop). Inserted into the text pipeline after ThinkingTagParser; transparent to existing structured-frame streams (no index-allocation changes), so no regression risk for opus 4.6 / sonnet 4.6.

Adds xml_tool_test.go plus repro/regress guard tests.