### PR TITLE
chore: list claude-opus-4.8 and kimi-k2.5 in /v1/models

### DIFF
--- a/main.go
+++ b/main.go
@@ -2874,16 +2874,18 @@ func startServer(port string) {
 			{"id": "claude-opus-4.5", "type": "model", "display_name": "Claude Opus 4.5", "created_at": "2025-01-01T00:00:00Z"},
 			{"id": "claude-opus-4.6", "type": "model", "display_name": "Claude Opus 4.6", "created_at": "2025-01-01T00:00:00Z"},
 			{"id": "claude-opus-4.7", "type": "model", "display_name": "Claude Opus 4.7", "created_at": "2025-01-01T00:00:00Z"},
+			{"id": "claude-opus-4.8", "type": "model", "display_name": "Claude Opus 4.8", "created_at": "2025-01-01T00:00:00Z"},
 			{"id": "claude-sonnet-4.6", "type": "model", "display_name": "Claude Sonnet 4.6", "created_at": "2025-01-01T00:00:00Z"},
 			{"id": "deepseek-3.2", "type": "model", "display_name": "DeepSeek 3.2", "created_at": "2025-01-01T00:00:00Z"},
 			{"id": "minimax-m2.5", "type": "model", "display_name": "MiniMax M2.5", "created_at": "2025-01-01T00:00:00Z"},
 			{"id": "glm-5", "type": "model", "display_name": "GLM-5", "created_at": "2025-01-01T00:00:00Z"},
+			{"id": "kimi-k2.5", "type": "model", "display_name": "Kimi K2.5", "created_at": "2025-01-01T00:00:00Z"},
 		}
 		resp := map[string]any{
 			"data":     models,
 			"has_more": false,
 			"first_id": "claude-sonnet-4.5",
-			"last_id":  "glm-5",
+			"last_id":  "kimi-k2.5",
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)


### PR DESCRIPTION
Both are already callable (present in ModelMap, added in #20) but were missing from the hardcoded /v1/models response, so clients that populate their model picker from /v1/models never saw them. Add both entries and update last_id to kimi-k2.5.