### PR TITLE
feat: add Bedrock Cohere Rerank 3.5 /v1/rerank endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ kiro2pi is a proxy server that translates Anthropic API requests to AWS CodeWhis
 - **main.go**: Single-file Go application containing all proxy logic
 - **Endpoints**:
   - `POST /v1/messages` - Anthropic API proxy (main endpoint)
+  - `POST /v1/embeddings` - Bedrock embeddings, OpenAI-compatible (only when Bedrock enabled)
+  - `POST /v1/rerank` - Bedrock Cohere Rerank 3.5, Cohere-compatible (only when Bedrock enabled)
   - `GET /health` - Health check
   - `/` - Catch-all (returns 404)
 
@@ -37,6 +39,11 @@ journalctl -u kiro2pi -f
 ### Debug Options
 - `DEBUG_SAVE_RAW=1`: Save raw API responses to `.raw` files
 - `DEBUG_ACCESS_LOG=1`: Enable detailed HTTP access logging (method, path, client IP)
+
+### Bedrock (optional, for `/v1/embeddings` and `/v1/rerank`)
+- `BEDROCK_ENABLED=1`: Enable the Bedrock-backed endpoints
+- `BEDROCK_AWS_PROFILE`: AWS shared-config profile (also enables the Bedrock endpoints)
+- `BEDROCK_REGION`: AWS region (default `us-west-2`). Rerank model is pinned to `cohere.rerank-v3-5:0`
 
 ## Systemd Service
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ eval $(./kiro2pi export)
 | `CODEWHISPERER_PROFILE_ARN` | Required if not using kiro-cli. Your CodeWhisperer profile ARN |
 | `DEBUG_SAVE_RAW` | Set to `1` or `true` to save raw API responses for debugging |
 | `DEBUG_ACCESS_LOG` | Set to `1` or `true` to enable detailed HTTP access logging |
+| `BEDROCK_ENABLED` | Set to `1` to enable the Bedrock-backed `/v1/embeddings` and `/v1/rerank` endpoints |
+| `BEDROCK_AWS_PROFILE` | AWS shared-config profile to use for Bedrock (also enables the Bedrock endpoints) |
+| `BEDROCK_REGION` | AWS region for Bedrock (default `us-west-2`) |
 
 ## Platform Support
 
@@ -197,6 +200,29 @@ The proxy maps model names to CodeWhisperer models:
 
 Hyphenated aliases are also supported (e.g. `claude-opus-4-7` → `claude-opus-4.7`).
 
+## Bedrock Endpoints (optional)
+
+When Bedrock is enabled (`BEDROCK_ENABLED=1` or `BEDROCK_AWS_PROFILE=...`), two extra endpoints are served using AWS credentials from the configured profile/region.
+
+### `POST /v1/rerank` (Cohere-compatible)
+
+Proxies to AWS Bedrock **Cohere Rerank 3.5** (`cohere.rerank-v3-5:0`). The `model` field is optional; if provided it must equal `cohere.rerank-v3-5:0` or the request is rejected with `400`. Documents may be strings or `{"text": "..."}` objects (max 1000).
+
+```bash
+curl http://localhost:9090/v1/rerank \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": "What is the capital of France?",
+    "documents": ["Paris is the capital of France.", "Berlin is in Germany."],
+    "top_n": 1,
+    "return_documents": true
+  }'
+```
+
+Response: `{ "id", "model", "results": [{ "index", "relevance_score", "document"? }], "meta" }`.
+
+Region note: Cohere Rerank 3.5 is available in `us-east-1`, `us-west-2`, `ap-northeast-1`, `ca-central-1`, and `eu-central-1`.
+
 ## API Endpoints
 
 | Endpoint | Description |
@@ -205,6 +231,8 @@ Hyphenated aliases are also supported (e.g. `claude-opus-4-7` → `claude-opus-4
 | `POST /v1/chat/completions` | OpenAI Chat Completions API (streaming & non-streaming) |
 | `POST /v1/completions` | OpenAI legacy Completions API |
 | `GET /v1/models` | List available models |
+| `POST /v1/embeddings` | Bedrock embeddings, OpenAI-compatible (requires Bedrock enabled) |
+| `POST /v1/rerank` | Bedrock Cohere Rerank 3.5, Cohere-compatible (requires Bedrock enabled) |
 | `GET /health` | Health check |
 | `GET /stats` | Call statistics (aggregated by model/day) |
 | `GET /logs` | Call log entries (paginated) |

--- a/main.go
+++ b/main.go
@@ -2493,6 +2493,156 @@ func handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// rerankModelID is the only Bedrock rerank model this proxy exposes.
+const rerankModelID = "cohere.rerank-v3-5:0"
+
+// cohereRerankMaxDocs is the per-request document limit for Cohere Rerank 3.5.
+const cohereRerankMaxDocs = 1000
+
+// handleRerank handles POST /v1/rerank requests (Cohere-compatible).
+// Forwards to AWS Bedrock Cohere Rerank 3.5 (cohere.rerank-v3-5:0).
+func handleRerank(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "只支持POST请求", http.StatusMethodNotAllowed)
+		return
+	}
+	if bedrockClient == nil {
+		http.Error(w, `{"error":{"message":"rerank not enabled"}}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"%v"}}`, err), http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	var req struct {
+		// Model is optional; this proxy only serves rerankModelID. A non-empty
+		// value that differs from it is rejected rather than silently overridden.
+		Model           string `json:"model"`
+		Query           string `json:"query"`
+		Documents       []any  `json:"documents"`
+		TopN            *int   `json:"top_n,omitempty"`
+		ReturnDocuments bool   `json:"return_documents,omitempty"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"%v"}}`, err), http.StatusBadRequest)
+		return
+	}
+	if req.Model != "" && req.Model != rerankModelID {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"unsupported model %q; only %q is available"}}`, req.Model, rerankModelID), http.StatusBadRequest)
+		return
+	}
+	if req.Query == "" {
+		http.Error(w, `{"error":{"message":"missing required field: query"}}`, http.StatusBadRequest)
+		return
+	}
+
+	// Normalize documents to []string. Accept ["str", ...] or [{"text": "..."}].
+	// Reject any other element shape: silently skipping would shift indices and
+	// make Bedrock's returned index point at the wrong source document.
+	docs := make([]string, 0, len(req.Documents))
+	for i, item := range req.Documents {
+		switch v := item.(type) {
+		case string:
+			docs = append(docs, v)
+		case map[string]any:
+			if s, ok := v["text"].(string); ok {
+				docs = append(docs, s)
+			} else {
+				http.Error(w, fmt.Sprintf(`{"error":{"message":"documents[%d] object missing string \"text\" field"}}`, i), http.StatusBadRequest)
+				return
+			}
+		default:
+			http.Error(w, fmt.Sprintf(`{"error":{"message":"documents[%d] must be a string or {\"text\":...} object"}}`, i), http.StatusBadRequest)
+			return
+		}
+	}
+	if len(docs) == 0 {
+		http.Error(w, `{"error":{"message":"documents is empty"}}`, http.StatusBadRequest)
+		return
+	}
+	if len(docs) > cohereRerankMaxDocs {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"too many documents: %d (max %d)"}}`, len(docs), cohereRerankMaxDocs), http.StatusBadRequest)
+		return
+	}
+
+	topN := len(docs)
+	if req.TopN != nil && *req.TopN > 0 && *req.TopN < topN {
+		topN = *req.TopN
+	}
+
+	start := time.Now()
+
+	// Bedrock rerank payload (shared by Cohere 3.5 and Amazon Rerank 1.0).
+	payload, _ := json.Marshal(map[string]any{
+		"query":       req.Query,
+		"documents":   docs,
+		"top_n":       topN,
+		"api_version": 2,
+	})
+	out, err := bedrockClient.InvokeModel(context.Background(), &bedrockruntime.InvokeModelInput{
+		ModelId:     aws.String(rerankModelID),
+		ContentType: aws.String("application/json"),
+		Body:        payload,
+	})
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"%v"}}`, err), http.StatusBadGateway)
+		return
+	}
+
+	var bedrockResp struct {
+		Results []struct {
+			Index          int     `json:"index"`
+			RelevanceScore float64 `json:"relevance_score"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(out.Body, &bedrockResp); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":{"message":"%v"}}`, err), http.StatusBadGateway)
+		return
+	}
+
+	// Build Cohere-compatible response.
+	results := make([]map[string]any, 0, len(bedrockResp.Results))
+	for _, rr := range bedrockResp.Results {
+		entry := map[string]any{
+			"index":           rr.Index,
+			"relevance_score": rr.RelevanceScore,
+		}
+		if req.ReturnDocuments && rr.Index >= 0 && rr.Index < len(docs) {
+			entry["document"] = map[string]any{"text": docs[rr.Index]}
+		}
+		results = append(results, entry)
+	}
+	resp := map[string]any{
+		"id":      uuid.New().String(),
+		"model":   rerankModelID,
+		"results": results,
+		"meta": map[string]any{
+			"api_version": map[string]any{"version": "2"},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+
+	// Log to observability.
+	if observDB != nil {
+		latency := time.Since(start).Milliseconds()
+		tokens := len(req.Query) / 4
+		for _, d := range docs {
+			tokens += len(d) / 4
+		}
+		go func() {
+			observDB.Exec(
+				`INSERT INTO call_log (id,created_at,model,endpoint,stream,input_tokens,latency_ms,status_code) VALUES (?,?,?,?,?,?,?,?)`,
+				uuid.New().String(), time.Now().UTC().Format(time.RFC3339), rerankModelID, "/v1/rerank", 0, tokens, latency, 200,
+			)
+		}()
+	}
+}
+
 // startServer 启动HTTP代理服务器
 func startServer(port string) {
 	// Initialize observability database
@@ -3006,6 +3156,7 @@ func startServer(port string) {
 	// Embeddings endpoint (conditional)
 	if bedrockClient != nil {
 		mux.HandleFunc("/v1/embeddings", logMiddleware(handleEmbeddings))
+		mux.HandleFunc("/v1/rerank", logMiddleware(handleRerank))
 	}
 
 	// 添加404处理
@@ -3024,6 +3175,7 @@ func startServer(port string) {
 	fmt.Printf("  GET  /logs        - 调用日志\n")
 	if bedrockClient != nil {
 		fmt.Printf("  POST /v1/embeddings - Bedrock Embeddings (OpenAI兼容)\n")
+		fmt.Printf("  POST /v1/rerank     - Bedrock Rerank (Cohere兼容)\n")
 	}
 	fmt.Printf("按Ctrl+C停止服务器\n")
 


### PR DESCRIPTION
Add a Cohere-compatible POST /v1/rerank handler that proxies to AWS Bedrock Cohere Rerank 3.5 (cohere.rerank-v3-5:0), served alongside the existing /v1/embeddings endpoint when Bedrock is enabled.

- Pin model to cohere.rerank-v3-5:0; reject a mismatched client model
- Accept string or {text:...} documents; reject other shapes to keep Bedrock result indices aligned with the source array
- Guard document count (Cohere max 1000)
- Return Cohere-shaped {id, model, results, meta}; honor return_documents
- Log calls to observability DB
- Document Bedrock endpoints and BEDROCK_* env vars in README/AGENTS